### PR TITLE
fixed unsigned npartTotal and npartHighWord

### DIFF
--- a/gadgetheader.h
+++ b/gadgetheader.h
@@ -30,7 +30,7 @@
     /** Boolean to test the presence of feedback*/
     int32_t  flag_feedback;
     /** First 32-bits of total number of particles in the simulation*/
-    int32_t  npartTotal[N_TYPE];
+    uint32_t  npartTotal[N_TYPE];
     /** Boolean to test the presence of cooling */
     int32_t  flag_cooling;
     /** Number of files expected in this snapshot*/
@@ -49,7 +49,7 @@
     int32_t  flag_metals;
     /** Long word of the total number of particles in the simulation. 
      * At least one version of N-GenICs sets this to something entirely different. */
-    int32_t  NallHW[N_TYPE];
+    uint32_t  NallHW[N_TYPE];
     int32_t flag_entropy_instead_u;	/*!< flags that IC-file contains entropy instead of u */
     int32_t flag_doubleprecision;	/*!< flags that snapshot contains double-precision instead of single precision */
 


### PR DESCRIPTION
For more than 2^32 particles in a snapshot, npartTotal and NallHW need to be combined, assuming that both are unsigned ints (for proof, see io.c in the Gadget source).  Otherwise the total number of particles is incorrect.  I've tested this with a snapshot that has 2240^3 particles.
